### PR TITLE
Fix lamport transfer order and replace unsafe methods in refund function

### DIFF
--- a/src/instructions/checker.rs
+++ b/src/instructions/checker.rs
@@ -17,10 +17,10 @@ pub fn checker(accounts: &[AccountInfo], bump: [u8; 1]) -> ProgramResult {
 
     // Check that the owner of the vault is the maker
     assert_eq!(&fundraiser_account.maker(), unsafe {
-        &TokenAccount::from_account_info_unsafe(maker_ta).authority()
+        &TokenAccount::from_account_info_unchecked(maker_ta)?.authority()
     });
 
-    let vault_account = unsafe { TokenAccount::from_account_info_unsafe(vault) };
+    let vault_account = unsafe { TokenAccount::from_account_info_unchecked(vault)? };
     // Save the current amount of the vault
     let amount = vault_account.amount();
 

--- a/src/instructions/contribute.rs
+++ b/src/instructions/contribute.rs
@@ -1,8 +1,15 @@
+use pinocchio::{
+    account_info::AccountInfo,
+    sysvars::{clock::Clock, Sysvar},
+    ProgramResult,
+};
+use pinocchio_token::{instructions::Transfer, state::TokenAccount};
 use solana_nostd_sha256::hashv;
-use pinocchio::{account_info::AccountInfo, sysvars::{clock::Clock, Sysvar}, ProgramResult};
-use pinocchio_token::{state::TokenAccount, instructions::Transfer};
 
-use crate::{state::{Contributor, Fundraiser}, ID, PDA_MARKER};
+use crate::{
+    state::{Contributor, Fundraiser},
+    ID, PDA_MARKER,
+};
 
 pub fn contribute(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     let [contributor, fundraiser, contributor_account, contributor_ta, vault, _token_program] =
@@ -15,17 +22,14 @@ pub fn contribute(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
         .split_first()
         .ok_or(pinocchio::program_error::ProgramError::InvalidInstructionData)?;
 
-    let pda = hashv(&[
-        fundraiser.key().as_ref(),
-        &[*bump],
-        ID.as_ref(),
-        PDA_MARKER,
-    ]);
+    let pda = hashv(&[fundraiser.key().as_ref(), &[*bump], ID.as_ref(), PDA_MARKER]);
 
     assert_eq!(pda, vault.key().as_ref());
 
     let fundraiser_account = Fundraiser::from_account_info(fundraiser);
-    assert_eq!(fundraiser_account.mint_to_raise(), unsafe { TokenAccount::from_account_info_unsafe(vault).mint() });
+    assert_eq!(fundraiser_account.mint_to_raise(), unsafe {
+        TokenAccount::from_account_info_unchecked(vault)?.mint()
+    });
 
     let amount = unsafe { *(data.as_ptr() as *const u64) };
 
@@ -33,23 +37,24 @@ pub fn contribute(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
         unsafe {
             // Get a mutable pointer to the account's data once
             let data_ptr = contributor_account.borrow_mut_data_unchecked().as_mut_ptr();
-    
+
             // Calculate the new amount and store it in the correct position (32-byte offset)
-            *(data_ptr.add(32) as *mut [u8; 8]) = (Contributor::from_account_info(contributor_account).amount() + amount).to_le_bytes();
+            *(data_ptr.add(32) as *mut [u8; 8]) =
+                (Contributor::from_account_info(contributor_account).amount() + amount)
+                    .to_le_bytes();
         }
     } else {
         unsafe {
             // Get a mutable pointer to the account's data
             let data_ptr = contributor_account.borrow_mut_data_unchecked().as_mut_ptr();
-    
+
             // Store the contributor key at the start (32 bytes)
             *(data_ptr as *mut [u8; 32]) = *contributor.key();
-    
+
             // Store the amount in the next 8 bytes (32-byte offset)
             *(data_ptr.add(32) as *mut [u8; 8]) = amount.to_le_bytes();
         }
     }
-    
 
     let current_time = Clock::get()?.unix_timestamp;
     assert!(fundraiser_account.time_ending() > current_time);

--- a/src/instructions/refund.rs
+++ b/src/instructions/refund.rs
@@ -2,10 +2,10 @@ use pinocchio::{
     account_info::AccountInfo,
     instruction::{Seed, Signer},
     sysvars::{clock::Clock, Sysvar},
-    ProgramResult, msg,
+    ProgramResult,
 };
 
-use pinocchio_token::{state::TokenAccount, instructions::Transfer};
+use pinocchio_token::{instructions::Transfer, state::TokenAccount};
 
 use crate::state::{Contributor, Fundraiser};
 
@@ -25,7 +25,7 @@ pub fn refund(accounts: &[AccountInfo], bump: [u8; 1]) -> ProgramResult {
     assert!(fundraiser_account.time_ending() >= current_time);
 
     // // Make sure that we didn0t reach the goal
-    let vault_account = unsafe { TokenAccount::from_account_info_unchecked_unsafe(vault) };
+    let vault_account = unsafe { TokenAccount::from_account_info_unchecked(vault)? };
     assert!(fundraiser_account.amount_to_raise() > vault_account.amount());
     assert_eq!(fundraiser_account.mint_to_raise(), vault_account.mint());
 

--- a/src/instructions/refund.rs
+++ b/src/instructions/refund.rs
@@ -42,8 +42,8 @@ pub fn refund(accounts: &[AccountInfo], bump: [u8; 1]) -> ProgramResult {
 
     unsafe {
         let lamports = contributor_account.borrow_lamports_unchecked();
-        *(contributor_account.borrow_mut_lamports_unchecked()) -= lamports;
-        *(contributor.borrow_mut_lamports_unchecked()) += lamports;
+        *contributor.borrow_mut_lamports_unchecked() += lamports;
+        *contributor_account.borrow_mut_lamports_unchecked() -= lamports;
 
         // contributor.realloc(0, true)?;
     }


### PR DESCRIPTION
Refactoring: Replaces unsafe account info methods with unchecked variants across several files to improve code safety and consistency. Bug Fix: Corrects the lamport transfer order in the `refund` function to prevent `UnbalancedInstruction` errors during execution.